### PR TITLE
added http method to verify access logic

### DIFF
--- a/ApiAuthTokenGenerator.Tests/V1/AcceptanceTests/VerifyTokenAcceptanceTests.cs
+++ b/ApiAuthTokenGenerator.Tests/V1/AcceptanceTests/VerifyTokenAcceptanceTests.cs
@@ -56,9 +56,10 @@ namespace ApiAuthTokenGenerator.Tests.V1.AcceptanceTests
             var apiName = _fixture.Create<string>();
             var tokenData = new AuthToken
             {
-                ApiEndpointName = lambdaRequest.RequestContext.ResourcePath,
+                ApiEndpointName = lambdaRequest.RequestContext.Path,
                 ApiName = apiName,
                 Environment = lambdaRequest.RequestContext.Stage,
+                HttpMethodType = lambdaRequest.RequestContext.HttpMethod,
                 Enabled = true,
                 ExpirationDate = null
             };

--- a/ApiAuthTokenGenerator.Tests/V1/Helpers/VerifyAccessHelperTests.cs
+++ b/ApiAuthTokenGenerator.Tests/V1/Helpers/VerifyAccessHelperTests.cs
@@ -44,7 +44,6 @@ namespace ApiAuthTokenGenerator.Tests.V1.Helpers
             result.Should().BeFalse();
         }
         [Test]
-        [Ignore("value can vary if used local or from AWS API Gateway")]
         public void IfEnvironmentInRequestDoesNotMatchDatabaseRecordShouldReturnFalse()
         {
             var request = GenerateAuthorizerRequest();
@@ -55,7 +54,6 @@ namespace ApiAuthTokenGenerator.Tests.V1.Helpers
             result.Should().BeFalse();
         }
         [Test]
-        [Ignore("Redundant")]
         public void IfApiNametInRequestDoesNotMatchDatabaseRecordShouldReturnFalse()
         {
             var request = GenerateAuthorizerRequest();
@@ -65,13 +63,22 @@ namespace ApiAuthTokenGenerator.Tests.V1.Helpers
             result.Should().BeFalse();
         }
         [Test]
-        [Ignore("Value is not path to endpoint")]
         public void IfApiEndpointNametInRequestDoesNotMatchDatabaseRecordShouldReturnFalse()
         {
             var request = GenerateAuthorizerRequest();
             var apiName = _faker.Random.Word();
             var tokenData = GenerateTokenData(request, apiName);
             tokenData.ApiEndpointName = _faker.Random.Word();
+            var result = VerifyAccessHelper.ShouldHaveAccess(request, tokenData, apiName);
+            result.Should().BeFalse();
+        }
+        [Test]
+        public void IfHttpMethodTypetInRequestDoesNotMatchDatabaseRecordShouldReturnFalse()
+        {
+            var request = GenerateAuthorizerRequest();
+            var apiName = _faker.Random.Word();
+            var tokenData = GenerateTokenData(request, apiName);
+            tokenData.HttpMethodType = _faker.Random.AlphaNumeric(6);
             var result = VerifyAccessHelper.ShouldHaveAccess(request, tokenData, apiName);
             result.Should().BeFalse();
         }
@@ -90,6 +97,7 @@ namespace ApiAuthTokenGenerator.Tests.V1.Helpers
             {
                 ApiEndpointName = _faker.Random.Word(),
                 ApiAwsId = _faker.Random.Word(),
+                HttpMethodType = _faker.Random.AlphaNumeric(6),
                 Environment = _faker.Random.Word(),
             };
         }
@@ -101,6 +109,7 @@ namespace ApiAuthTokenGenerator.Tests.V1.Helpers
                 ApiEndpointName = request.ApiEndpointName,
                 ApiName = apiName,
                 Environment = request.Environment,
+                HttpMethodType = request.HttpMethodType,
                 ExpirationDate = null,
                 Enabled = true,
             };

--- a/ApiAuthTokenGenerator.Tests/V1/TestHelper/AuthTokenDatabaseEntityHelper.cs
+++ b/ApiAuthTokenGenerator.Tests/V1/TestHelper/AuthTokenDatabaseEntityHelper.cs
@@ -25,6 +25,7 @@ namespace ApiAuthTokenGenerator.Tests.V1.Helper
                 ConsumerTypeLookupId = entity.ConsumerTypeLookupId,
                 DateCreated = entity.DateCreated,
                 Environment = entity.Environment,
+                HttpMethodType = entity.HttpMethodType,
                 ExpirationDate = entity.ExpirationDate,
                 RequestedBy = entity.RequestedBy,
                 Enabled = entity.Enabled

--- a/ApiAuthTokenGenerator.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
+++ b/ApiAuthTokenGenerator.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
@@ -65,6 +65,7 @@ namespace ApiAuthTokenGenerator.Tests.V1.UseCase
             {
                 ApiEndpointName = request.ApiEndpointName,
                 ApiName = apiName,
+                HttpMethodType = request.HttpMethodType,
                 Environment = request.Environment,
                 Enabled = true,
                 ExpirationDate = null

--- a/ApiAuthTokenGenerator/LambdaHandler.cs
+++ b/ApiAuthTokenGenerator/LambdaHandler.cs
@@ -41,9 +41,10 @@ namespace ApiAuthTokenGenerator
             {
                 var authorizerRequest = new AuthorizerRequest
                 {
-                    ApiEndpointName = request.RequestContext.ResourcePath,
+                    ApiEndpointName = request.RequestContext.Path,
                     ApiAwsId = request.RequestContext.ApiId,
                     Environment = request.RequestContext.Stage,
+                    HttpMethodType = request.RequestContext.HttpMethod,
                     Token = request.Headers["Authorisation"]
                 };
                 var verifyAccessUseCase = _serviceProvider.GetService<IVerifyAccessUseCase>();

--- a/ApiAuthTokenGenerator/V1/Boundary/AuthorizerRequest.cs
+++ b/ApiAuthTokenGenerator/V1/Boundary/AuthorizerRequest.cs
@@ -11,5 +11,6 @@ namespace ApiAuthTokenGenerator.V1.Boundary
         public string Environment { get; set; }
         public string ApiAwsId { get; set; }
         public string ApiEndpointName { get; set; }
+        public string HttpMethodType { get; set; }
     }
 }

--- a/ApiAuthTokenGenerator/V1/Helpers/VerifyAccessHelper.cs
+++ b/ApiAuthTokenGenerator/V1/Helpers/VerifyAccessHelper.cs
@@ -12,9 +12,11 @@ namespace ApiAuthTokenGenerator.V1.Helpers
         {
             //Check that the token is enabled or that the expiration date is valid
             if (!tokenData.Enabled
-                || (tokenData.ExpirationDate != null && tokenData.ExpirationDate < DateTime.Now))
-            /* Redundant
-            || tokenData.ApiName != apiName)*/
+                || (tokenData.ExpirationDate != null && tokenData.ExpirationDate < DateTime.Now)
+                || tokenData.ApiName != apiName
+                || tokenData.HttpMethodType != authorizerRequest.HttpMethodType
+                || tokenData.Environment != authorizerRequest.Environment
+                || !authorizerRequest.ApiEndpointName.Contains(tokenData.ApiEndpointName, StringComparison.InvariantCulture))
             {
                 LambdaLogger.Log($"Token with id {tokenData.Id} denying access for {tokenData.ApiName} with endpoint {tokenData.ApiEndpointName}" +
                    $" in {tokenData.Environment} stage does not have access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
@@ -23,7 +25,7 @@ namespace ApiAuthTokenGenerator.V1.Helpers
             }
 
             LambdaLogger.Log($"Token with id {tokenData.Id} allowing access for {tokenData.ApiName} with endpoint {tokenData.ApiEndpointName}" +
-                   $" in {tokenData.Environment} stage does not have access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
+                   $" in {tokenData.Environment} stage has access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
                    $"for {authorizerRequest.Environment} stage { tokenData.Enabled }");
 
             return true;


### PR DESCRIPTION
- Added http method type property to verify access logic
- changed to using "Path", instead of "ResourcePath" due to "ResourcePath" returning empty values
- "Path" property contains the full path of the request, rather than just the endpoint path (e.g. it returns "/staging/staging-resident-vulnerabilities-api/api/v1/resident-vulnerabilities" instead of "api/v1/resident-vulnerabilities"), but is the only property containing path information

TODO: Improve verify access logic in regards to api endpoint name (to be done as part of separate task). 