### PR TITLE
Upgrade .NET 3.1 => 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       - image: "hashicorp/terraform:0.12.29"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:8.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       - image: "hashicorp/terraform:0.12.29"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/core/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
+++ b/ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -14,17 +14,17 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ApiAuthVerifyToken.Tests/DatabaseTests.cs
+++ b/ApiAuthVerifyToken.Tests/DatabaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ApiAuthVerifyToken.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -14,6 +15,7 @@ namespace ApiAuthVerifyToken.Tests
         [SetUp]
         public void RunBeforeAnyTests()
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             var builder = new DbContextOptionsBuilder();
             builder.UseNpgsql(ConnectionString.TestDatabase());
             DatabaseContext = new TokenDatabaseContext(builder.Options);

--- a/ApiAuthVerifyToken.Tests/Dockerfile
+++ b/ApiAuthVerifyToken.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/ApiAuthVerifyToken.Tests/V1/AcceptanceTests/VerifyTokenAcceptanceTests.cs
+++ b/ApiAuthVerifyToken.Tests/V1/AcceptanceTests/VerifyTokenAcceptanceTests.cs
@@ -40,8 +40,8 @@ namespace ApiAuthVerifyToken.Tests.V1.AcceptanceTests
             _mockAwsStsGateway = new Mock<IAwsStsGateway>();
             _mockDynamoDbGateway = new Mock<IDynamoDbGateway>();
             //set up env vars
-            Environment.SetEnvironmentVariable("jwtSecret", _fixture.Create<string>());
-            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(25));
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
+            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(50));
             //set up JWT tokens
             _allowedGroups = new List<string> { _faker.Random.Word(), _faker.Random.Word() };
             _jwtServiceFlow = GenerateJwtHelper.GenerateJwtToken();
@@ -91,7 +91,7 @@ namespace ApiAuthVerifyToken.Tests.V1.AcceptanceTests
             var lambdaRequest = _fixture.Build<APIGatewayCustomAuthorizerRequest>().Create();
             lambdaRequest.Headers["Authorization"] = _jwtServiceFlow;
             //change jwt secret to simulate failure of validating token
-            Environment.SetEnvironmentVariable("jwtSecret", _fixture.Create<string>());
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
             var result = _classUnderTest.VerifyToken(lambdaRequest);
 
             result.Should().BeOfType<APIGatewayCustomAuthorizerResponse>();

--- a/ApiAuthVerifyToken.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
+++ b/ApiAuthVerifyToken.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
@@ -54,7 +54,7 @@ namespace ApiAuthVerifyToken.Tests.V1.UseCase
         {
             var request = GenerateAuthorizerRequest(GenerateJwtHelper.GenerateJwtToken());
             //change key to simulate failed validation
-            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(16));
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
             var result = _classUnderTest.ExecuteServiceAuth(request);
             result.Allow.Should().BeFalse();
             result.User.Should().Be("user");

--- a/ApiAuthVerifyToken.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
+++ b/ApiAuthVerifyToken.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
@@ -32,8 +32,8 @@ namespace ApiAuthVerifyToken.Tests.V1.UseCase
             _mockAwsStsGateway = new Mock<IAwsStsGateway>();
             _mockDynamoDbGateway = new Mock<IDynamoDbGateway>();
             _classUnderTest = new VerifyAccessUseCase(_mockDatabaseGateway.Object, _mockAwsApiGateway.Object, _mockAwsStsGateway.Object, _mockDynamoDbGateway.Object);
-            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(25));
-            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(25));
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
+            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(50));
         }
         #region Service Auth Flow
 

--- a/ApiAuthVerifyToken/ApiAuthVerifyToken.csproj
+++ b/ApiAuthVerifyToken/ApiAuthVerifyToken.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     </PropertyGroup>
 
@@ -22,17 +22,17 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" />
   </ItemGroup>
 
 </Project>

--- a/ApiAuthVerifyToken/ConfigureServices.cs
+++ b/ApiAuthVerifyToken/ConfigureServices.cs
@@ -17,6 +17,7 @@ namespace ApiAuthVerifyToken
 
             var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
 
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             services.AddDbContext<TokenDatabaseContext>(
                 opt => opt.UseNpgsql(connectionString));
 

--- a/ApiAuthVerifyToken/Dockerfile
+++ b/ApiAuthVerifyToken/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /app
 

--- a/ApiAuthVerifyToken/V1/Helpers/VerifyAccessHelper.cs
+++ b/ApiAuthVerifyToken/V1/Helpers/VerifyAccessHelper.cs
@@ -21,13 +21,13 @@ namespace ApiAuthVerifyToken.V1.Helpers
             {
                 LambdaLogger.Log($"Token with id {tokenData.Id} denying access for {tokenData.ApiName} with endpoint {tokenData.ApiEndpointName}" +
                    $" in {tokenData.Environment} stage does not have access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
-                   $"for {authorizerRequest.Environment} stage { tokenData.Enabled }");
+                   $"for {authorizerRequest.Environment} stage {tokenData.Enabled}");
                 return false;
             }
 
             LambdaLogger.Log($"Token with id {tokenData.Id} allowing access for {tokenData.ApiName} with endpoint {tokenData.ApiEndpointName}" +
                    $" in {tokenData.Environment} stage has access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
-                   $"for {authorizerRequest.Environment} stage { tokenData.Enabled }");
+                   $"for {authorizerRequest.Environment} stage {tokenData.Enabled}");
 
             return true;
         }

--- a/ApiAuthVerifyToken/build.cmd
+++ b/ApiAuthVerifyToken/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/api-auth-verify-token.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/api-auth-verify-token.zip

--- a/ApiAuthVerifyToken/build.sh
+++ b/ApiAuthVerifyToken/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/api-auth-verify-token.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/api-auth-verify-token.zip

--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -1,12 +1,12 @@
 service: api-auth-verify-token
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet8
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
 package:
-  artifact: ./bin/release/netcoreapp3.1/api-auth-verify-token.zip
+  artifact: ./bin/release/net8.0/api-auth-verify-token.zip
 
 functions:
   ApiAuthVerifyToken:

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .PHONY: setup
 setup:
-	docker-compose build
+	docker compose build
 
 .PHONY: build
 build:
-	docker-compose build base-api
+	docker compose build base-api
 
 .PHONY: serve
 serve:
-	docker-compose build base-api && docker-compose up base-api
+	docker compose build base-api && docker compose up base-api
 
 .PHONY: shell
 shell:
-	docker-compose run base-api bash
+	docker compose run base-api bash
 
 .PHONY: test
 test:
-	docker-compose up test-database & docker-compose build base-api-test && docker-compose up base-api-test
+	docker compose up test-database & docker compose build base-api-test && docker compose up base-api-test
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Upgrade API to .NET 8.0 as 6.0 has reached End of Support.

**TODO BEFORE MERGING:**

This PR updates the `System.IdentityModel.Tokens.Jwt` package, including a vulnerability fix. See [here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/IDX10720) for more details. Before merging, we need to confirm the key we use fits the new security requirements or this will introduce breaking changes.