### PR TITLE
Fix syntax in serverless yml

### DIFF
--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -215,7 +215,7 @@ custom:
   desAccountIds:
     development: "549011513230"
     staging: "549011513230"
-    production: "658402009206
+    production: "658402009206"
   disasterRecoveryAccountIds:
     production: "851725205572"
   vpc:


### PR DESCRIPTION
Fix an error which was because there was an unterminated quotation mark in the account ID