### PR TITLE
TS-2076 add conditional policy deployments

### DIFF
--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -25,7 +25,11 @@ resources:
       - ${self:provider.stage}
       - "production"
     #pre-production is self contained with its own authorizer
-    EnableCrossAccountAccess: !Not [!Equals [!${self:provider.stage}, "pre-production"]]
+    EnableCrossAccountAccess: 
+      Fn::Not:
+      - Fn::Equals:
+        - ${self:provider.stage}
+        - "pre-production"
 
   Resources:
     AllowApisAccountAuthorizer:
@@ -157,7 +161,7 @@ resources:
                     - "lambda:InvokeFunction"
                   Resource: "*"
           - PolicyName: assumeRoleForGettingCredentialsApiAccount
-            # ProductionApis, StagingApis and housing-pre-production
+            # ProductionApis, StagingApis and Housing-Pre-Production
             PolicyDocument:
               Version: "2012-10-17"
               Statement:
@@ -170,32 +174,36 @@ resources:
                       - - "arn:aws:iam::"
                         - Ref: "AWS::AccountId"
                         - ":role/LBH_Api_Gateway_Allow_GET"
-          - PolicyName: assumeRoleForGettingCredentialsHousingAccount
+          - !If 
+            - EnableCrossAccountAccess              
+            - PolicyName: assumeRoleForGettingCredentialsHousingAccount
             # Housing-Production or Housing-Staging
-            Condition: EnableCrossAccountAccess
-            PolicyDocument:
-              Version: "2012-10-17"
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - "sts:AssumeRole"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:iam::"
-                        - ${self:custom.housingAccountIds.${self:provider.stage}}
-                        - ":role/LBH_Api_Gateway_Allow_GET"
-          - PolicyName: assumeRoleForGettingCredentialsDESAccount
-            # Document-Evidence-Store Staging and Production
-            Condition: EnableCrossAccountAccess
-            PolicyDocument:
-              Version: "2012-10-17"
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - "sts:AssumeRole"
-                  Resource:
-                    Fn::Sub: arn:aws:iam::${self:custom.desAccountIds.${self:provider.stage}}:role/LBH_Api_Gateway_Allow_GET
+              PolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - "sts:AssumeRole"
+                    Resource:
+                      Fn::Join:
+                        - ""
+                        - - "arn:aws:iam::"
+                          - ${self:custom.housingAccountIds.${self:provider.stage}}
+                          - ":role/LBH_Api_Gateway_Allow_GET"
+            - !Ref AWS::NoValue
+          - !If 
+            - EnableCrossAccountAccess
+            - PolicyName: assumeRoleForGettingCredentialsDESAccount
+              # Document-Evidence-Store Staging and Production
+              PolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - "sts:AssumeRole"
+                    Resource:
+                      Fn::Sub: arn:aws:iam::${self:custom.desAccountIds.${self:provider.stage}}:role/LBH_Api_Gateway_Allow_GET
+            - !Ref AWS::NoValue
           - PolicyName: getAPIGatewayAPIName
             PolicyDocument:
               Version: "2012-10-17"
@@ -224,10 +232,13 @@ custom:
     development: "364864573329"
     staging: "087586271961"
     production: "282997303675"
+    pre-production: "578479666894" 
   desAccountIds:
     development: "549011513230"
     staging: "549011513230"
     production: "658402009206"
+    #dummy account number to ensure all variables can be resolved for all stages. Won't be actually used for any resources
+    pre-production: "111111111111" 
   disasterRecoveryAccountIds:
     production: "851725205572"
   vpc:
@@ -250,7 +261,8 @@ custom:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
     pre-production:
+      securityGroupIds:
+        - sg-08dd301b41ec262e2
       subnetIds:
         - subnet-08aa35159a8706faa
         - subnet-0b848c5b14f841dfb
-

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -47,7 +47,7 @@ resource "aws_dynamodb_table" "api_authenticator_dynamodb_table" {
     project_name      = "api-authenticator"
     Application       = "API Authenticator"
     TeamEmail         = "developementteam@hackney.gov.uk"
-    BackupPolicy      = "Dev"
+    BackupPolicy      = "Prod"
     Confidentiality   = "Internal"
   }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -47,7 +47,7 @@ resource "aws_dynamodb_table" "api_authenticator_dynamodb_table" {
     project_name      = "api-authenticator"
     Application       = "API Authenticator"
     TeamEmail         = "developementteam@hackney.gov.uk"
-    BackupPolicy      = "Stg"
+    BackupPolicy      = "Prod"
     Confidentiality   = "Internal"
   }
 


### PR DESCRIPTION
1. Only deploy certain `lambdaExecutionRole` policies when they are required. Some are not needed on pre-prod
2.  Add dummy account id for DES pre-production. This is so that all variables can be resolved. If they can't be resolved even for resources that won't be deployed due to conditions the deployment will fail
3. Revert the DynamoDB backup policies to Prod on staging and development environment to match what's currently set on AWS